### PR TITLE
Flycheck Checker: Suspicious state

### DIFF
--- a/flycheck-clang-analyzer.el
+++ b/flycheck-clang-analyzer.el
@@ -197,7 +197,10 @@ See `https://github.com/alexmurray/clang-analyzer/'."
   :verify flycheck-clang-analyzer--verify
   :error-patterns ((warning line-start (file-name) ":" line ":" column
                             ": warning: " (optional (message))
-                            line-end))
+                            line-end)
+		   (error line-start (file-name) ":" line ":" column
+			  ": error: " (optional (message))
+			  line-end))
   :error-filter
   (lambda (errors)
     (let ((errors (flycheck-sanitize-errors errors)))

--- a/flycheck-clang-analyzer.el
+++ b/flycheck-clang-analyzer.el
@@ -195,9 +195,12 @@ See `https://github.com/alexmurray/clang-analyzer/'."
   :predicate flycheck-clang-analyzer--predicate
   :working-directory flycheck-clang-analyzer--get-default-directory
   :verify flycheck-clang-analyzer--verify
-  :error-patterns ((warning line-start (file-name) ":" line ":" column
-                            ": warning: " (optional (message))
+  :error-patterns ((info line-start (file-name) ":" line ":" column
+                            ": note: " (optional (message))
                             line-end)
+		   (warning line-start (file-name) ":" line ":" column
+			    ": warning: " (optional (message))
+			    line-end)
 		   (error line-start (file-name) ":" line ":" column
 			  ": error: " (optional (message))
 			  line-end))


### PR DESCRIPTION
When installing flycheck-clang-analyzer via MELPA (20180215.345) along side clang-5.0.1, GNU emacs 25.3.1, and cquery (commit 080dd431) flycheck reports a suspicious state because the pattern won't match `": error: "` that `clang --analyze` outputs.

I've added both "info" and "error" warning definitions with the appropriate matching patterns. This change should be completely backwards compatible as the original warning pattern still exists and functions as it did before!