### PR TITLE
Update "rest" to "cl-rest"

### DIFF
--- a/flycheck-clang-analyzer.el
+++ b/flycheck-clang-analyzer.el
@@ -88,7 +88,7 @@
 (defun flycheck-clang-analyzer--cquery-get-compile-options ()
   "Get compile options from cquery."
   (if (fboundp 'cquery-file-info)
-      (rest (gethash "args" (cquery-file-info)))))
+      (cl-rest (gethash "args" (cquery-file-info)))))
 
 (defun flycheck-clang-analyzer--cquery-get-default-directory ()
   "Get default directory from cquery."


### PR DESCRIPTION
Similar to my previous merge request #8 when installing flycheck-clang-analyzer via MELPA (20180215.345) with GNU emacs 25.3.1. Emacs reports `rest` as undefined. I changed this to the cl-lib defined cl-rest which should function identically.

I'm not sure if this change will effect backwards compatibility with those who have `rest` defined. If a strain of emacs still uses `rest` perhaps a more platform-free implementation would be better (perhaps an implementation using `&rest`).