### PR TITLE
Classify RTags as inactive if it can't provide compilation flags

### DIFF
--- a/flycheck-clang-analyzer.el
+++ b/flycheck-clang-analyzer.el
@@ -136,7 +136,8 @@
   (and (boundp 'rtags-enabled)
        rtags-enabled
        (fboundp 'rtags-is-running)
-       (rtags-is-running)))
+       (rtags-is-running)
+       (> (length (rtags-compilation-flags)) 0)))
 
 (defun flycheck-clang-analyzer--rtags-get-compile-options ()
   "Get compile options from rtags."


### PR DESCRIPTION
When working on a project, it's quite common to also open source files
outside of the current project. Trying to analyze those files will
inevitably fail because RTags can't provide compilation flags for them.

This modifies `flycheck-clang-analyzer--rtags-active' to consider RTags to
be inactive if it can't provide compilation flags for the current buffer,
even if it's enabled and running.